### PR TITLE
Drop ineffective cleanup commands

### DIFF
--- a/org.gnome.Showtime.json
+++ b/org.gnome.Showtime.json
@@ -11,17 +11,6 @@
         "--socket=wayland",
         "--socket=pulseaudio"
     ],
-    "cleanup": [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
-    ],
     "modules": [
         {
             "name": "showtime",


### PR DESCRIPTION
They are unnecessary because no files are affected by these commands.